### PR TITLE
[CON-318] Fix regression: initialize document context

### DIFF
--- a/src/js/changelog-topic.js
+++ b/src/js/changelog-topic.js
@@ -5,9 +5,12 @@ import ChangelogService from './changelog/ChangelogService';
 import ChangelogTagFactory from './changelog/ChangelogTagFactory';
 import YouTubeLoader from './changelog/YouTubeLoader';
 import { detectTopicFromUrl, formatDate, setMetaContent } from './shared/common';
+import { setDocumentContext } from './shared/context';
 
 import '../css/changelog.css';
 import { CHANGELOG_PATH_PREFIX, CHANGELOG_SUBPAGE_PARAM_NAME } from './changelog/config';
+
+setDocumentContext(document, document.location.hostname);
 
 const tagFactory = new ChangelogTagFactory();
 const youTubeLoader = new YouTubeLoader();

--- a/src/js/stacks.js
+++ b/src/js/stacks.js
@@ -11,6 +11,9 @@ import {
   STACKS_SUBPAGE_PARAM_NAME,
   STACKS_SUBPAGE_PATH_PREFIX,
 } from './stacks/config';
+import { setDocumentContext } from './shared/context';
+
+setDocumentContext(document, document.location.hostname);
 
 const stacksAPIBase = 'https://stacks.bitrise.io/';
 


### PR DESCRIPTION
setMetaContent (via getDocumentContext) was called in stacks.js and changelog-topic.js without a prior setDocumentContext call, causing a runtime error after the context module was introduced.

Ticket: https://bitrise.atlassian.net/browse/CON-318