### PR TITLE
[CON-319] Fix SSR template accumulation and batch integrations DOM mutations

### DIFF
--- a/src/css/integrations.css
+++ b/src/css/integrations.css
@@ -22,3 +22,8 @@
   padding-top: 2.5rem;
   padding-bottom: 2.5rem;
 }
+
+.step-card {
+  content-visibility: auto;
+  contain-intrinsic-size: 0 200px;
+}

--- a/src/js/integrations/StepListSection.js
+++ b/src/js/integrations/StepListSection.js
@@ -19,7 +19,15 @@ class StepListSection {
    */
   render(integrations) {
     const { document } = getDocumentContext();
-    this.gridContainer.querySelectorAll('.step_grid').forEach((grid) => grid.classList.add('display-none'));
+    this.gridContainer.querySelectorAll('.step_grid').forEach((grid) => {
+      if (grid.querySelector('.category-anchor')) {
+        grid.remove();
+      } else {
+        grid.classList.add('display-none');
+      }
+    });
+
+    const fragment = document.createDocumentFragment();
 
     integrations.categories.getItems().forEach((category) => {
       /** @type {string[]} */
@@ -45,9 +53,11 @@ class StepListSection {
           newGrid.querySelector('.step-list').appendChild(newStepCard.element);
         });
 
-        this.gridContainer.appendChild(newGrid);
+        fragment.appendChild(newGrid);
       }
     });
+
+    this.gridContainer.appendChild(fragment);
   }
 
   /**
@@ -58,29 +68,34 @@ class StepListSection {
    * @param {string} queryFilter
    */
   update(integrations, platformFilter, categoryFilter, queryFilter) {
-    integrations.categories.getItems().forEach((category) => {
+    // Read phase: compute filter results and collect DOM references — no mutations
+    const updates = integrations.categories.getItems().flatMap((category) => {
       const categoryGrid = this.gridContainer.querySelector(`#category-${category.getSlug()}`)?.closest('.step_grid');
-      if (categoryGrid) {
-        /** @type {string[]} */
-        const matchingSteps = category.steps.filter((slug) => {
-          return (
+      if (!categoryGrid) return [];
+
+      /** @type {Set<string>} */
+      const matchingSlugs = new Set(
+        category.steps.filter(
+          (slug) =>
             !integrations.steps[slug].isDeprecated() &&
             integrations.steps[slug].fitsCategory(categoryFilter) &&
             integrations.steps[slug].fitsPlatform(platformFilter) &&
-            integrations.steps[slug].fitsQuery(queryFilter)
-          );
-        });
+            integrations.steps[slug].fitsQuery(queryFilter),
+        ),
+      );
 
-        categoryGrid.querySelectorAll('.step-card').forEach((card) => card.classList.add('display-none'));
-        if (matchingSteps.length > 0) {
-          matchingSteps.forEach((slug) =>
-            categoryGrid.querySelector(`#step-${slug}`)?.classList.remove('display-none'),
-          );
-          categoryGrid.classList.remove('display-none');
-        } else {
-          categoryGrid.classList.add('display-none');
-        }
-      }
+      const cards = Array.from(categoryGrid.querySelectorAll('.step-card'));
+      return [{ categoryGrid, matchingSlugs, cards }];
+    });
+
+    // Write phase: batch all DOM mutations in a single rAF
+    requestAnimationFrame(() => {
+      updates.forEach(({ categoryGrid, matchingSlugs, cards }) => {
+        cards.forEach((card) => {
+          card.classList.toggle('display-none', !matchingSlugs.has(card.id.slice('step-'.length)));
+        });
+        categoryGrid.classList.toggle('display-none', matchingSlugs.size === 0);
+      });
     });
   }
 }

--- a/src/js/integrations/ssr.js
+++ b/src/js/integrations/ssr.js
@@ -10,7 +10,7 @@ import IntegrationsService from './IntegrationsService';
  */
 export async function render({ destination, templateHostname }) {
   const [listTemplate, detailTemplate, integrations] = await Promise.all([
-    fetch(`https://${templateHostname}/integrations`).then((r) => r.text()),
+    fetch(`https://${templateHostname}/integrations?template=true`).then((r) => r.text()),
     fetch(`https://${templateHostname}/integrations/step`).then((r) => r.text()),
     IntegrationsService.loadIntegrations(),
   ]);

--- a/src/js/integrations/worker.js
+++ b/src/js/integrations/worker.js
@@ -82,12 +82,17 @@ export default {
       return setCorsHeaders(new Response('OK'));
     }
 
-    const prerenderedResponse = await fetchPrerenderedHtml(urlObject, ctx);
-    if (prerenderedResponse && prerenderedResponse.ok) {
-      return prerenderedResponse;
+    const isTemplateRequest = urlObject.searchParams.has('template');
+
+    if (!isTemplateRequest) {
+      const prerenderedResponse = await fetchPrerenderedHtml(urlObject, ctx);
+      if (prerenderedResponse && prerenderedResponse.ok) {
+        return prerenderedResponse;
+      }
     }
 
     urlObject.hostname = ORIGIN_HOST;
+    urlObject.searchParams.delete('template');
     canonical.hostname = 'bitrise.io';
 
     const routingMatch = routingPatterns


### PR DESCRIPTION
The prerenderer was fetching the live bitrise.io/integrations page as its template. Once prerendering went live that URL returns the full prerendered output, causing render() to accumulate an extra 10 category grids on every prerender run (28k-line HTML after 126 runs).

- worker.js: bypass prerendered GCS cache when ?template=true is present, strip the param before forwarding to the Webflow origin
- ssr.js: fetch /integrations?template=true so the prerenderer always gets the clean Webflow skeleton
- StepListSection.render(): remove previously rendered grids (identified by .category-anchor) on re-run; hide only the original Webflow template grid so HMR re-inits can still find the .step_grid reference; batch all new-grid insertions via DocumentFragment (single layout recalculation)
- StepListSection.update(): split into a pure read phase (JS only, no DOM mutations) and a write phase wrapped in requestAnimationFrame to batch all classList.toggle calls and prevent MutationObserver-triggered forced synchronous layouts from third-party trackers
- integrations.css: add content-visibility: auto to .step-card so the browser skips UpdateLayoutTree for off-screen cards

Ticket: https://bitrise.atlassian.net/browse/CON-319