### PR TITLE
Add home-redirect CF worker (ER-2723)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const { parse: parseToml } = require('smol-toml');
 const path = require('path');
 const crypto = require('crypto');
 const express = require('express');
@@ -83,22 +84,7 @@ async function discoverWorkers(dir) {
         await discoverWorkers(fullPath);
       } else if (entry.name === 'wrangler.toml') {
         const tomlContent = await fs.promises.readFile(fullPath, 'utf8');
-        // Basic TOML parsing - you may want to use a proper TOML parser library
-        const config = {};
-        const lines = tomlContent.split('\n');
-        lines.forEach((line) => {
-          const matchArray = line.match(/^(\w+)\s*=\s*\[(.*)\]$/);
-          if (matchArray) {
-            const [, key, value] = matchArray;
-            config[key] = JSON.parse(`[${value}]`);
-          } else {
-            const match = line.match(/^(\w+)\s*=\s*["']?([^"'\n]+)["']?/);
-            if (match) {
-              const [, key, value] = match;
-              config[key] = value;
-            }
-          }
-        });
+        const config = parseToml(tomlContent);
 
         workers.push({
           name: path.basename(path.dirname(fullPath)),
@@ -122,17 +108,21 @@ async function getWorker(urlObject) {
   }
 
   const matchedWorker = workers.filter((worker) => {
-    let route = worker.config.route ? worker.config.route : null;
-    if (!route && worker.config.routes) [route] = worker.config.routes;
-    if (!route) return false;
+    const routes = worker.config.routes
+      ? worker.config.routes
+      : worker.config.route
+        ? [worker.config.route]
+        : [];
 
-    let routePattern = route.replace('bitrise.io', '^');
-    if (routePattern.endsWith('*')) {
-      routePattern = routePattern.slice(0, -1);
-    } else {
-      routePattern = `${routePattern}$`;
-    }
-    return urlObject.pathname.match(new RegExp(routePattern));
+    return routes.some((route) => {
+      let routePattern = route.replace('bitrise.io', '^');
+      if (routePattern.endsWith('*')) {
+        routePattern = routePattern.slice(0, -1);
+      } else {
+        routePattern = `${routePattern}$`;
+      }
+      return urlObject.pathname.match(new RegExp(routePattern));
+    });
   });
 
   if (matchedWorker.length > 0) {
@@ -213,10 +203,16 @@ app.get(/\/.*/, async (req, res) => {
 
     process.stdout.write(`[info] Using request handler ${requestHandler.name} (${requestHandler.type})\n`);
 
+    const workerUrl = new URL(urlObject.href);
+    workerUrl.hostname = webflowDomain;
+    workerUrl.protocol = 'https:';
+    workerUrl.port = '';
+
     const fetchEvent = {
-      request: {
-        url: urlObject,
-      },
+      request: new Request(workerUrl.href, {
+        method: req.method,
+        headers: req.headers,
+      }),
       respondWith: async (buffer) => {
         const response = await buffer;
         res.statusCode = response.status;
@@ -232,7 +228,7 @@ app.get(/\/.*/, async (req, res) => {
         if (responseLocation)
           res.setHeader(
             'Location',
-            responseLocation.replace(webflowDomain, `${hostname}:${port}`).replace('https', 'http'),
+            responseLocation.replace(`https://${webflowDomain}`, `http://${hostname}:${port}`),
           );
 
         process.stdout.write(`[info] Serving ${urlObject.href} with status ${res.statusCode}\n`);
@@ -262,7 +258,7 @@ app.get(/\/.*/, async (req, res) => {
     }
 
     if (requestHandler.type === 'ES6 Module') {
-      const ctxMock = { waitUntil: () => {} };
+      const ctxMock = { waitUntil: () => {}, passThroughOnException: () => {} };
       fetchEvent.respondWith(requestHandler.handler.fetch(fetchEvent.request, {}, ctxMock));
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "jsdom": "^26.0.0",
         "markdown-it": "^13.0.1",
         "prettier": "^3.2.5",
+        "smol-toml": "^1.6.1",
         "style-loader": "^3.3.3",
         "webpack": "^5.94.0",
         "webpack-cli": "^5.1.4",
@@ -8547,6 +8548,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "jsdom": "^26.0.0",
     "markdown-it": "^13.0.1",
     "prettier": "^3.2.5",
+    "smol-toml": "^1.6.1",
     "style-loader": "^3.3.3",
     "webpack": "^5.94.0",
     "webpack-cli": "^5.1.4",

--- a/src/js/home-redirect/worker.js
+++ b/src/js/home-redirect/worker.js
@@ -1,0 +1,17 @@
+const REDIRECT_COOKIE = 'webflow_user_redirect';
+const APP_URL = 'https://app.bitrise.io';
+
+export default {
+  async fetch(request) {
+    const cookies = request.headers.get('Cookie') || '';
+    if (parseCookieValue(cookies, REDIRECT_COOKIE) === '1') {
+      return Response.redirect(APP_URL, 302);
+    }
+    return fetch(request);
+  },
+};
+
+function parseCookieValue(cookieHeader, name) {
+  const match = cookieHeader.match(new RegExp(`(?:^|;\\s*)${name}=([^;]*)`));
+  return match ? match[1] : null;
+}

--- a/src/js/home-redirect/worker.js
+++ b/src/js/home-redirect/worker.js
@@ -11,16 +11,18 @@ export default {
 
     const { pathname } = url;
 
+    const internalReferrer = isBitriseReferrer(request);
+
     if (env.DRY_RUN) {
       let action;
-      if (pathname === '/') action = isLoggedIn ? `redirect → ${APP_URL}` : 'passthrough';
+      if (pathname === '/') action = isLoggedIn && internalReferrer ? `redirect → ${APP_URL}` : 'passthrough';
       else if (pathname === '/home') action = isLoggedIn ? `fetch ${HOME_URL} from origin` : `redirect → ${HOME_URL}`;
-      console.log(`[home-redirect dry-run] path=${pathname} action=${action}`);
+      console.log(`[home-redirect dry-run] path=${pathname} referrer=${request.headers.get('Referer') || 'none'} action=${action}`);
       return fetch(request);
     }
 
     if (pathname === '/') {
-      return isLoggedIn ? Response.redirect(APP_URL, 302) : fetch(request);
+      return isLoggedIn && internalReferrer ? Response.redirect(APP_URL, 302) : fetch(request);
     }
 
     if (pathname === '/home') {
@@ -37,4 +39,13 @@ export default {
 function parseCookieValue(cookieHeader, name) {
   const match = cookieHeader.match(new RegExp(`(?:^|;\\s*)${name}=([^;]*)`));
   return match ? match[1] : null;
+}
+
+function isBitriseReferrer(request) {
+  const referrer = request.headers.get('Referer') || '';
+  try {
+    return new URL(referrer).hostname === 'bitrise.io';
+  } catch {
+    return false;
+  }
 }

--- a/src/js/home-redirect/worker.js
+++ b/src/js/home-redirect/worker.js
@@ -2,7 +2,8 @@ const REDIRECT_COOKIE = 'webflow_user_redirect';
 const APP_URL = 'https://app.bitrise.io';
 
 export default {
-  async fetch(request) {
+  async fetch(request, env, ctx) {
+    ctx.passThroughOnException();
     const cookies = request.headers.get('Cookie') || '';
     if (parseCookieValue(cookies, REDIRECT_COOKIE) === '1') {
       return Response.redirect(APP_URL, 302);

--- a/src/js/home-redirect/worker.js
+++ b/src/js/home-redirect/worker.js
@@ -1,35 +1,40 @@
 const REDIRECT_COOKIE = 'webflow_user_redirect';
 const APP_URL = 'https://app.bitrise.io';
-const HOME_URL = 'https://bitrise.io/';
+const BITRISE_ROOT = 'https://bitrise.io/';
+const BITRISE_HOME = 'https://bitrise.io/home';
 
 export default {
   async fetch(request, env, ctx) {
     ctx.passThroughOnException();
-    const url = new URL(request.url);
+    const { pathname } = new URL(request.url);
     const cookies = request.headers.get('Cookie') || '';
     const isLoggedIn = parseCookieValue(cookies, REDIRECT_COOKIE) === '1';
 
-    const { pathname } = url;
-
-    const internalReferrer = isBitriseReferrer(request);
-
     if (env.DRY_RUN) {
       let action;
-      if (pathname === '/') action = isLoggedIn && internalReferrer ? `redirect → ${APP_URL}` : 'passthrough';
-      else if (pathname === '/home') action = isLoggedIn ? `fetch ${HOME_URL} from origin` : `redirect → ${HOME_URL}`;
+      if (pathname === '/') {
+        if (!isLoggedIn) action = 'passthrough';
+        else action = isBitriseReferrer(request) ? `redirect → ${BITRISE_HOME}` : `redirect → ${APP_URL}`;
+      } else if (pathname === '/home') {
+        action = `fetch ${BITRISE_ROOT} from origin (no cookie)`;
+      }
       console.log(`[home-redirect dry-run] path=${pathname} referrer=${request.headers.get('Referer') || 'none'} action=${action}`);
       return fetch(request);
     }
 
     if (pathname === '/') {
-      return isLoggedIn && internalReferrer ? Response.redirect(APP_URL, 302) : fetch(request);
+      if (!isLoggedIn) return fetch(request);
+      return isBitriseReferrer(request)
+        ? Response.redirect(BITRISE_HOME, 302)
+        : Response.redirect(APP_URL, 302);
     }
 
     if (pathname === '/home') {
-      if (!isLoggedIn) return Response.redirect(HOME_URL, 302);
-      // Origin has a 301 /home → / which would loop back through this worker.
-      // Fetch / directly from origin so the subrequest bypasses worker routing.
-      return fetch(new Request(HOME_URL, request));
+      // Origin has a 301 /home → / so fetch / directly to avoid a redirect loop.
+      // Strip cookies so the origin sees an anonymous request.
+      const headers = new Headers(request.headers);
+      headers.delete('Cookie');
+      return fetch(BITRISE_ROOT, { headers });
     }
 
     return fetch(request);

--- a/src/js/home-redirect/worker.js
+++ b/src/js/home-redirect/worker.js
@@ -9,21 +9,27 @@ export default {
     const cookies = request.headers.get('Cookie') || '';
     const isLoggedIn = parseCookieValue(cookies, REDIRECT_COOKIE) === '1';
 
-    let redirectTo = null;
-    if (url.pathname === '/') {
-      redirectTo = isLoggedIn ? APP_URL : null;
-    } else if (url.pathname === '/home') {
-      redirectTo = isLoggedIn ? null : HOME_URL;
-    }
+    const { pathname } = url;
 
     if (env.DRY_RUN) {
-      console.log(`[home-redirect dry-run] path=${url.pathname} action=${redirectTo ? 'redirect → ' + redirectTo : 'passthrough'}`);
+      let action;
+      if (pathname === '/') action = isLoggedIn ? `redirect → ${APP_URL}` : 'passthrough';
+      else if (pathname === '/home') action = isLoggedIn ? `fetch ${HOME_URL} from origin` : `redirect → ${HOME_URL}`;
+      console.log(`[home-redirect dry-run] path=${pathname} action=${action}`);
       return fetch(request);
     }
 
-    if (redirectTo) {
-      return Response.redirect(redirectTo, 302);
+    if (pathname === '/') {
+      return isLoggedIn ? Response.redirect(APP_URL, 302) : fetch(request);
     }
+
+    if (pathname === '/home') {
+      if (!isLoggedIn) return Response.redirect(HOME_URL, 302);
+      // Origin has a 301 /home → / which would loop back through this worker.
+      // Fetch / directly from origin so the subrequest bypasses worker routing.
+      return fetch(new Request(HOME_URL, request));
+    }
+
     return fetch(request);
   },
 };

--- a/src/js/home-redirect/worker.js
+++ b/src/js/home-redirect/worker.js
@@ -1,12 +1,28 @@
 const REDIRECT_COOKIE = 'webflow_user_redirect';
 const APP_URL = 'https://app.bitrise.io';
+const HOME_URL = 'https://bitrise.io/';
 
 export default {
   async fetch(request, env, ctx) {
     ctx.passThroughOnException();
+    const url = new URL(request.url);
     const cookies = request.headers.get('Cookie') || '';
-    if (parseCookieValue(cookies, REDIRECT_COOKIE) === '1') {
-      return Response.redirect(APP_URL, 302);
+    const isLoggedIn = parseCookieValue(cookies, REDIRECT_COOKIE) === '1';
+
+    let redirectTo = null;
+    if (url.pathname === '/') {
+      redirectTo = isLoggedIn ? APP_URL : null;
+    } else if (url.pathname === '/home') {
+      redirectTo = isLoggedIn ? null : HOME_URL;
+    }
+
+    if (env.DRY_RUN) {
+      console.log(`[home-redirect dry-run] path=${url.pathname} action=${redirectTo ? 'redirect → ' + redirectTo : 'passthrough'}`);
+      return fetch(request);
+    }
+
+    if (redirectTo) {
+      return Response.redirect(redirectTo, 302);
     }
     return fetch(request);
   },

--- a/src/js/home-redirect/worker.js
+++ b/src/js/home-redirect/worker.js
@@ -27,7 +27,7 @@ export default {
     if (pathname === '/home') {
       if (!isLoggedIn) return redirect(BITRISE_ROOT);
       // /home doesn't exist on origin; fetch / directly to serve the marketing homepage.
-      // Strip cookies so the origin sees an anonymous request.
+      // Strip cookies so the origin sees a non-logged-in request.
       const headers = new Headers(request.headers);
       headers.delete('Cookie');
       return withNoCacheHeaders(await fetch(BITRISE_ROOT, { headers }));

--- a/src/js/home-redirect/worker.js
+++ b/src/js/home-redirect/worker.js
@@ -21,11 +21,11 @@ export default {
 
     if (pathname === '/') {
       if (!isLoggedIn) return withNoCacheHeaders(await fetch(request));
-      return redirect(isBitriseReferrer(request) ? BITRISE_HOME : APP_URL);
+      return withNoCacheHeaders(Response.redirect(isBitriseReferrer(request) ? BITRISE_HOME : APP_URL, 302));
     }
 
     if (pathname === '/home') {
-      if (!isLoggedIn) return redirect(BITRISE_ROOT);
+      if (!isLoggedIn) return withNoCacheHeaders(Response.redirect(BITRISE_ROOT, 302));
       // /home doesn't exist on origin; fetch / directly to serve the marketing homepage.
       // Strip cookies so the origin sees a non-logged-in request.
       const headers = new Headers(request.headers);
@@ -37,14 +37,7 @@ export default {
   },
 };
 
-function redirect(url) {
-  return new Response(null, {
-    status: 302,
-    headers: { 'Location': url, ...NO_CACHE_HEADERS },
-  });
-}
-
-async function withNoCacheHeaders(response) {
+function withNoCacheHeaders(response) {
   const headers = new Headers(response.headers);
   for (const [key, value] of Object.entries(NO_CACHE_HEADERS)) {
     headers.set(key, value);

--- a/src/js/home-redirect/worker.js
+++ b/src/js/home-redirect/worker.js
@@ -25,7 +25,7 @@ export default {
     }
 
     if (pathname === '/home') {
-      // Origin has a 301 /home → / so fetch / directly to avoid a redirect loop.
+      // /home doesn't exist on origin; fetch / directly to serve the marketing homepage.
       // Strip cookies so the origin sees an anonymous request.
       const headers = new Headers(request.headers);
       headers.delete('Cookie');

--- a/src/js/home-redirect/worker.js
+++ b/src/js/home-redirect/worker.js
@@ -3,30 +3,25 @@ const APP_URL = 'https://app.bitrise.io';
 const BITRISE_ROOT = 'https://bitrise.io/';
 const BITRISE_HOME = 'https://bitrise.io/home';
 
+// Prevents browsers and CDNs from caching responses and bypassing worker logic
+// on subsequent visits. Vary ensures cookie/referrer changes invalidate CDN entries.
+const NO_CACHE_HEADERS = {
+  'Cache-Control': 'no-store, no-cache, must-revalidate, private',
+  'Pragma': 'no-cache',
+  'Expires': '0',
+  'Vary': 'Cookie, Referer',
+};
+
 export default {
-  async fetch(request, env, ctx) {
+  async fetch(request, _env, ctx) {
     ctx.passThroughOnException();
     const { pathname } = new URL(request.url);
     const cookies = request.headers.get('Cookie') || '';
     const isLoggedIn = parseCookieValue(cookies, REDIRECT_COOKIE) === '1';
 
-    if (env.DRY_RUN) {
-      let action;
-      if (pathname === '/') {
-        if (!isLoggedIn) action = 'passthrough';
-        else action = isBitriseReferrer(request) ? `redirect → ${BITRISE_HOME}` : `redirect → ${APP_URL}`;
-      } else if (pathname === '/home') {
-        action = `fetch ${BITRISE_ROOT} from origin (no cookie)`;
-      }
-      console.log(`[home-redirect dry-run] path=${pathname} referrer=${request.headers.get('Referer') || 'none'} action=${action}`);
-      return fetch(request);
-    }
-
     if (pathname === '/') {
-      if (!isLoggedIn) return fetch(request);
-      return isBitriseReferrer(request)
-        ? Response.redirect(BITRISE_HOME, 302)
-        : Response.redirect(APP_URL, 302);
+      if (!isLoggedIn) return withNoCacheHeaders(await fetch(request));
+      return redirect(isBitriseReferrer(request) ? BITRISE_HOME : APP_URL);
     }
 
     if (pathname === '/home') {
@@ -34,12 +29,27 @@ export default {
       // Strip cookies so the origin sees an anonymous request.
       const headers = new Headers(request.headers);
       headers.delete('Cookie');
-      return fetch(BITRISE_ROOT, { headers });
+      return withNoCacheHeaders(await fetch(BITRISE_ROOT, { headers }));
     }
 
     return fetch(request);
   },
 };
+
+function redirect(url) {
+  return new Response(null, {
+    status: 302,
+    headers: { 'Location': url, ...NO_CACHE_HEADERS },
+  });
+}
+
+async function withNoCacheHeaders(response) {
+  const headers = new Headers(response.headers);
+  for (const [key, value] of Object.entries(NO_CACHE_HEADERS)) {
+    headers.set(key, value);
+  }
+  return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
+}
 
 function parseCookieValue(cookieHeader, name) {
   const match = cookieHeader.match(new RegExp(`(?:^|;\\s*)${name}=([^;]*)`));

--- a/src/js/home-redirect/worker.js
+++ b/src/js/home-redirect/worker.js
@@ -60,7 +60,7 @@ function parseCookieValue(cookieHeader, name) {
 function isBitriseReferrer(request) {
   const referrer = request.headers.get('Referer') || '';
   try {
-    return new URL(referrer).hostname === 'bitrise.io';
+    return new URL(referrer).hostname.includes('bitrise');
   } catch {
     return false;
   }

--- a/src/js/home-redirect/worker.js
+++ b/src/js/home-redirect/worker.js
@@ -33,6 +33,7 @@ export default {
       return withNoCacheHeaders(await fetch(BITRISE_ROOT, { headers }));
     }
 
+    // Intended to be unreachable: wrangler.toml routes this worker only to / and /home
     return fetch(request);
   },
 };

--- a/src/js/home-redirect/worker.js
+++ b/src/js/home-redirect/worker.js
@@ -25,6 +25,7 @@ export default {
     }
 
     if (pathname === '/home') {
+      if (!isLoggedIn) return redirect(BITRISE_ROOT);
       // /home doesn't exist on origin; fetch / directly to serve the marketing homepage.
       // Strip cookies so the origin sees an anonymous request.
       const headers = new Headers(request.headers);

--- a/src/js/home-redirect/wrangler.toml
+++ b/src/js/home-redirect/wrangler.toml
@@ -1,0 +1,6 @@
+name = "home-redirect"
+main = "./worker.js"
+compatibility_date = "2026-05-15"
+route = "bitrise.io/"
+no_bundle = true
+workers_dev = true

--- a/src/js/home-redirect/wrangler.toml
+++ b/src/js/home-redirect/wrangler.toml
@@ -1,6 +1,14 @@
 name = "home-redirect"
 main = "./worker.js"
 compatibility_date = "2026-05-15"
-route = "bitrise.io/"
+routes = [
+  "bitrise.io/",
+  "bitrise.io/home"
+]
 no_bundle = true
 workers_dev = true
+
+# Uncomment to deploy in dry-run mode: logs what the worker would do without redirecting.
+# Watch output with: npx wrangler tail --config src/js/home-redirect/wrangler.toml
+# [vars]
+# DRY_RUN = true

--- a/src/js/home-redirect/wrangler.toml
+++ b/src/js/home-redirect/wrangler.toml
@@ -7,8 +7,3 @@ routes = [
 ]
 no_bundle = true
 workers_dev = true
-
-# Uncomment to deploy in dry-run mode: logs what the worker would do without redirecting.
-# Watch output with: npx wrangler tail --config src/js/home-redirect/wrangler.toml
-# [vars]
-# DRY_RUN = true

--- a/test/js/home-redirect/worker.test.js
+++ b/test/js/home-redirect/worker.test.js
@@ -11,41 +11,55 @@ beforeEach(() => {
   mockFetch.mockResolvedValue(new Response('OK'));
 });
 
-function makeRequest(url, cookies = '') {
-  return new Request(url, {
-    headers: cookies ? { Cookie: cookies } : {},
-  });
-}
-
 function fetch(url, cookies = '') {
-  return worker.fetch(makeRequest(url, cookies), {}, ctx);
+  return worker.fetch(
+    new Request(url, { headers: cookies ? { Cookie: cookies } : {} }),
+    {},
+    ctx,
+  );
 }
 
-describe('home-redirect worker', () => {
-  it('redirects to app.bitrise.io when redirect cookie is present', async () => {
+describe('/ (root)', () => {
+  it('redirects to app.bitrise.io when logged in', async () => {
     const response = await fetch('https://bitrise.io/', 'webflow_user_redirect=1');
     expect(response.status).toBe(302);
     expect(response.headers.get('Location')).toBe('https://app.bitrise.io/');
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('passes through when redirect cookie is absent', async () => {
+  it('passes through when not logged in', async () => {
     await fetch('https://bitrise.io/');
-    expect(mockFetch).toHaveBeenCalledWith(expect.objectContaining({ url: 'https://bitrise.io/' }));
+    expect(mockFetch).toHaveBeenCalled();
   });
 
-  it('passes through when redirect cookie has a value other than 1', async () => {
+  it('passes through when cookie value is not 1', async () => {
     await fetch('https://bitrise.io/', 'webflow_user_redirect=0');
     expect(mockFetch).toHaveBeenCalled();
   });
+});
 
-  it('ignores unrelated cookies and passes through', async () => {
-    await fetch('https://bitrise.io/', 'session=abc123; tracking=xyz');
+describe('/home', () => {
+  it('passes through when logged in (escape hatch)', async () => {
+    await fetch('https://bitrise.io/home', 'webflow_user_redirect=1');
     expect(mockFetch).toHaveBeenCalled();
   });
 
-  it('redirects when redirect cookie appears among other cookies', async () => {
-    const response = await fetch('https://bitrise.io/', 'session=abc123; webflow_user_redirect=1; other=val');
+  it('redirects to root when not logged in', async () => {
+    const response = await fetch('https://bitrise.io/home');
     expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('https://bitrise.io/');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('cookie parsing', () => {
+  it('redirects at root when cookie appears among other cookies', async () => {
+    const response = await fetch('https://bitrise.io/', 'session=abc; webflow_user_redirect=1; other=val');
+    expect(response.status).toBe(302);
+  });
+
+  it('does not redirect at /home when cookie appears among other cookies', async () => {
+    await fetch('https://bitrise.io/home', 'session=abc; webflow_user_redirect=1; other=val');
+    expect(mockFetch).toHaveBeenCalled();
   });
 });

--- a/test/js/home-redirect/worker.test.js
+++ b/test/js/home-redirect/worker.test.js
@@ -4,6 +4,8 @@ import worker from '../../../src/js/home-redirect/worker';
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
+const ctx = { passThroughOnException: vi.fn() };
+
 beforeEach(() => {
   mockFetch.mockReset();
   mockFetch.mockResolvedValue(new Response('OK'));
@@ -15,33 +17,35 @@ function makeRequest(url, cookies = '') {
   });
 }
 
+function fetch(url, cookies = '') {
+  return worker.fetch(makeRequest(url, cookies), {}, ctx);
+}
+
 describe('home-redirect worker', () => {
   it('redirects to app.bitrise.io when redirect cookie is present', async () => {
-    const response = await worker.fetch(makeRequest('https://bitrise.io/', 'webflow_user_redirect=1'));
+    const response = await fetch('https://bitrise.io/', 'webflow_user_redirect=1');
     expect(response.status).toBe(302);
     expect(response.headers.get('Location')).toBe('https://app.bitrise.io/');
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it('passes through when redirect cookie is absent', async () => {
-    await worker.fetch(makeRequest('https://bitrise.io/'));
+    await fetch('https://bitrise.io/');
     expect(mockFetch).toHaveBeenCalledWith(expect.objectContaining({ url: 'https://bitrise.io/' }));
   });
 
   it('passes through when redirect cookie has a value other than 1', async () => {
-    await worker.fetch(makeRequest('https://bitrise.io/', 'webflow_user_redirect=0'));
+    await fetch('https://bitrise.io/', 'webflow_user_redirect=0');
     expect(mockFetch).toHaveBeenCalled();
   });
 
   it('ignores unrelated cookies and passes through', async () => {
-    await worker.fetch(makeRequest('https://bitrise.io/', 'session=abc123; tracking=xyz'));
+    await fetch('https://bitrise.io/', 'session=abc123; tracking=xyz');
     expect(mockFetch).toHaveBeenCalled();
   });
 
   it('redirects when redirect cookie appears among other cookies', async () => {
-    const response = await worker.fetch(
-      makeRequest('https://bitrise.io/', 'session=abc123; webflow_user_redirect=1; other=val'),
-    );
+    const response = await fetch('https://bitrise.io/', 'session=abc123; webflow_user_redirect=1; other=val');
     expect(response.status).toBe(302);
   });
 });

--- a/test/js/home-redirect/worker.test.js
+++ b/test/js/home-redirect/worker.test.js
@@ -19,68 +19,61 @@ function fetch(url, { cookies = '', referrer = '' } = {}) {
 }
 
 describe('/ (root)', () => {
-  it('redirects to app.bitrise.io when logged in and referred from bitrise.io', async () => {
+  it('passes through when not logged in', async () => {
+    await fetch('https://bitrise.io/');
+    expect(mockFetch).toHaveBeenCalled();
+  });
+
+  it('passes through when not logged in even with a bitrise referrer', async () => {
+    await fetch('https://bitrise.io/', { referrer: 'https://bitrise.io/pricing' });
+    expect(mockFetch).toHaveBeenCalled();
+  });
+
+  it('redirects to /home when logged in with a bitrise.io referrer', async () => {
     const response = await fetch('https://bitrise.io/', {
       cookies: 'webflow_user_redirect=1',
       referrer: 'https://bitrise.io/blog',
     });
     expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('https://bitrise.io/home');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('redirects to app.bitrise.io when logged in with no referrer', async () => {
+    const response = await fetch('https://bitrise.io/', { cookies: 'webflow_user_redirect=1' });
+    expect(response.status).toBe(302);
     expect(response.headers.get('Location')).toBe('https://app.bitrise.io/');
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('passes through when logged in but referred from an external site', async () => {
-    await fetch('https://bitrise.io/', {
+  it('redirects to app.bitrise.io when logged in with an external referrer', async () => {
+    const response = await fetch('https://bitrise.io/', {
       cookies: 'webflow_user_redirect=1',
       referrer: 'https://google.com',
     });
-    expect(mockFetch).toHaveBeenCalled();
-  });
-
-  it('passes through when logged in with no referrer', async () => {
-    await fetch('https://bitrise.io/', { cookies: 'webflow_user_redirect=1' });
-    expect(mockFetch).toHaveBeenCalled();
-  });
-
-  it('passes through when not logged in', async () => {
-    await fetch('https://bitrise.io/', { referrer: 'https://bitrise.io/pricing' });
-    expect(mockFetch).toHaveBeenCalled();
-  });
-
-  it('passes through when cookie value is not 1', async () => {
-    await fetch('https://bitrise.io/', {
-      cookies: 'webflow_user_redirect=0',
-      referrer: 'https://bitrise.io/pricing',
-    });
-    expect(mockFetch).toHaveBeenCalled();
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('https://app.bitrise.io/');
   });
 });
 
 describe('/home', () => {
-  it('fetches root from origin when logged in, avoiding the origin 301 /home→/ loop', async () => {
+  it('fetches root from origin without cookie when logged in', async () => {
     await fetch('https://bitrise.io/home', { cookies: 'webflow_user_redirect=1' });
-    expect(mockFetch).toHaveBeenCalledWith(expect.objectContaining({ url: 'https://bitrise.io/' }));
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://bitrise.io/',
+      expect.objectContaining({ headers: expect.any(Headers) }),
+    );
+    const passedHeaders = mockFetch.mock.calls[0][1].headers;
+    expect(passedHeaders.get('Cookie')).toBeNull();
   });
 
-  it('redirects to root when not logged in', async () => {
-    const response = await fetch('https://bitrise.io/home');
-    expect(response.status).toBe(302);
-    expect(response.headers.get('Location')).toBe('https://bitrise.io/');
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
-});
-
-describe('cookie parsing', () => {
-  it('redirects at root when cookie appears among other cookies', async () => {
-    const response = await fetch('https://bitrise.io/', {
-      cookies: 'session=abc; webflow_user_redirect=1; other=val',
-      referrer: 'https://bitrise.io/pricing',
-    });
-    expect(response.status).toBe(302);
-  });
-
-  it('fetches root from origin at /home when cookie appears among other cookies', async () => {
-    await fetch('https://bitrise.io/home', { cookies: 'session=abc; webflow_user_redirect=1; other=val' });
-    expect(mockFetch).toHaveBeenCalledWith(expect.objectContaining({ url: 'https://bitrise.io/' }));
+  it('fetches root from origin without cookie when not logged in', async () => {
+    await fetch('https://bitrise.io/home');
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://bitrise.io/',
+      expect.objectContaining({ headers: expect.any(Headers) }),
+    );
+    const passedHeaders = mockFetch.mock.calls[0][1].headers;
+    expect(passedHeaders.get('Cookie')).toBeNull();
   });
 });

--- a/test/js/home-redirect/worker.test.js
+++ b/test/js/home-redirect/worker.test.js
@@ -11,36 +11,54 @@ beforeEach(() => {
   mockFetch.mockResolvedValue(new Response('OK'));
 });
 
-function fetch(url, cookies = '') {
-  return worker.fetch(
-    new Request(url, { headers: cookies ? { Cookie: cookies } : {} }),
-    {},
-    ctx,
-  );
+function fetch(url, { cookies = '', referrer = '' } = {}) {
+  const headers = {};
+  if (cookies) headers['Cookie'] = cookies;
+  if (referrer) headers['Referer'] = referrer;
+  return worker.fetch(new Request(url, { headers }), {}, ctx);
 }
 
 describe('/ (root)', () => {
-  it('redirects to app.bitrise.io when logged in', async () => {
-    const response = await fetch('https://bitrise.io/', 'webflow_user_redirect=1');
+  it('redirects to app.bitrise.io when logged in and referred from bitrise.io', async () => {
+    const response = await fetch('https://bitrise.io/', {
+      cookies: 'webflow_user_redirect=1',
+      referrer: 'https://bitrise.io/blog',
+    });
     expect(response.status).toBe(302);
     expect(response.headers.get('Location')).toBe('https://app.bitrise.io/');
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  it('passes through when logged in but referred from an external site', async () => {
+    await fetch('https://bitrise.io/', {
+      cookies: 'webflow_user_redirect=1',
+      referrer: 'https://google.com',
+    });
+    expect(mockFetch).toHaveBeenCalled();
+  });
+
+  it('passes through when logged in with no referrer', async () => {
+    await fetch('https://bitrise.io/', { cookies: 'webflow_user_redirect=1' });
+    expect(mockFetch).toHaveBeenCalled();
+  });
+
   it('passes through when not logged in', async () => {
-    await fetch('https://bitrise.io/');
+    await fetch('https://bitrise.io/', { referrer: 'https://bitrise.io/pricing' });
     expect(mockFetch).toHaveBeenCalled();
   });
 
   it('passes through when cookie value is not 1', async () => {
-    await fetch('https://bitrise.io/', 'webflow_user_redirect=0');
+    await fetch('https://bitrise.io/', {
+      cookies: 'webflow_user_redirect=0',
+      referrer: 'https://bitrise.io/pricing',
+    });
     expect(mockFetch).toHaveBeenCalled();
   });
 });
 
 describe('/home', () => {
   it('fetches root from origin when logged in, avoiding the origin 301 /home→/ loop', async () => {
-    await fetch('https://bitrise.io/home', 'webflow_user_redirect=1');
+    await fetch('https://bitrise.io/home', { cookies: 'webflow_user_redirect=1' });
     expect(mockFetch).toHaveBeenCalledWith(expect.objectContaining({ url: 'https://bitrise.io/' }));
   });
 
@@ -54,12 +72,15 @@ describe('/home', () => {
 
 describe('cookie parsing', () => {
   it('redirects at root when cookie appears among other cookies', async () => {
-    const response = await fetch('https://bitrise.io/', 'session=abc; webflow_user_redirect=1; other=val');
+    const response = await fetch('https://bitrise.io/', {
+      cookies: 'session=abc; webflow_user_redirect=1; other=val',
+      referrer: 'https://bitrise.io/pricing',
+    });
     expect(response.status).toBe(302);
   });
 
   it('fetches root from origin at /home when cookie appears among other cookies', async () => {
-    await fetch('https://bitrise.io/home', 'session=abc; webflow_user_redirect=1; other=val');
+    await fetch('https://bitrise.io/home', { cookies: 'session=abc; webflow_user_redirect=1; other=val' });
     expect(mockFetch).toHaveBeenCalledWith(expect.objectContaining({ url: 'https://bitrise.io/' }));
   });
 });

--- a/test/js/home-redirect/worker.test.js
+++ b/test/js/home-redirect/worker.test.js
@@ -39,9 +39,9 @@ describe('/ (root)', () => {
 });
 
 describe('/home', () => {
-  it('passes through when logged in (escape hatch)', async () => {
+  it('fetches root from origin when logged in, avoiding the origin 301 /home→/ loop', async () => {
     await fetch('https://bitrise.io/home', 'webflow_user_redirect=1');
-    expect(mockFetch).toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledWith(expect.objectContaining({ url: 'https://bitrise.io/' }));
   });
 
   it('redirects to root when not logged in', async () => {
@@ -58,8 +58,8 @@ describe('cookie parsing', () => {
     expect(response.status).toBe(302);
   });
 
-  it('does not redirect at /home when cookie appears among other cookies', async () => {
+  it('fetches root from origin at /home when cookie appears among other cookies', async () => {
     await fetch('https://bitrise.io/home', 'session=abc; webflow_user_redirect=1; other=val');
-    expect(mockFetch).toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledWith(expect.objectContaining({ url: 'https://bitrise.io/' }));
   });
 });

--- a/test/js/home-redirect/worker.test.js
+++ b/test/js/home-redirect/worker.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import worker from '../../../src/js/home-redirect/worker';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockFetch.mockResolvedValue(new Response('OK'));
+});
+
+function makeRequest(url, cookies = '') {
+  return new Request(url, {
+    headers: cookies ? { Cookie: cookies } : {},
+  });
+}
+
+describe('home-redirect worker', () => {
+  it('redirects to app.bitrise.io when redirect cookie is present', async () => {
+    const response = await worker.fetch(makeRequest('https://bitrise.io/', 'webflow_user_redirect=1'));
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('https://app.bitrise.io/');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('passes through when redirect cookie is absent', async () => {
+    await worker.fetch(makeRequest('https://bitrise.io/'));
+    expect(mockFetch).toHaveBeenCalledWith(expect.objectContaining({ url: 'https://bitrise.io/' }));
+  });
+
+  it('passes through when redirect cookie has a value other than 1', async () => {
+    await worker.fetch(makeRequest('https://bitrise.io/', 'webflow_user_redirect=0'));
+    expect(mockFetch).toHaveBeenCalled();
+  });
+
+  it('ignores unrelated cookies and passes through', async () => {
+    await worker.fetch(makeRequest('https://bitrise.io/', 'session=abc123; tracking=xyz'));
+    expect(mockFetch).toHaveBeenCalled();
+  });
+
+  it('redirects when redirect cookie appears among other cookies', async () => {
+    const response = await worker.fetch(
+      makeRequest('https://bitrise.io/', 'session=abc123; webflow_user_redirect=1; other=val'),
+    );
+    expect(response.status).toBe(302);
+  });
+});

--- a/test/js/home-redirect/worker.test.js
+++ b/test/js/home-redirect/worker.test.js
@@ -8,7 +8,7 @@ const ctx = { passThroughOnException: vi.fn() };
 
 beforeEach(() => {
   mockFetch.mockReset();
-  mockFetch.mockResolvedValue(new Response('OK'));
+  mockFetch.mockResolvedValue(new Response('OK', { headers: { 'Content-Type': 'text/html' } }));
 });
 
 function fetch(url, { cookies = '', referrer = '' } = {}) {
@@ -18,32 +18,33 @@ function fetch(url, { cookies = '', referrer = '' } = {}) {
   return worker.fetch(new Request(url, { headers }), {}, ctx);
 }
 
+function expectNoCacheHeaders(response) {
+  expect(response.headers.get('Cache-Control')).toBe('no-store, no-cache, must-revalidate, private');
+  expect(response.headers.get('Vary')).toBe('Cookie, Referer');
+}
+
 describe('/ (root)', () => {
-  it('passes through when not logged in', async () => {
-    await fetch('https://bitrise.io/');
+  it('passes through with no-cache headers when not logged in', async () => {
+    const response = await fetch('https://bitrise.io/');
     expect(mockFetch).toHaveBeenCalled();
+    expectNoCacheHeaders(response);
   });
 
-  it('passes through when not logged in even with a bitrise referrer', async () => {
-    await fetch('https://bitrise.io/', { referrer: 'https://bitrise.io/pricing' });
-    expect(mockFetch).toHaveBeenCalled();
-  });
-
-  it('redirects to /home when logged in with a bitrise.io referrer', async () => {
+  it('redirects to /home with no-cache headers when logged in with a bitrise.io referrer', async () => {
     const response = await fetch('https://bitrise.io/', {
       cookies: 'webflow_user_redirect=1',
       referrer: 'https://bitrise.io/blog',
     });
     expect(response.status).toBe(302);
     expect(response.headers.get('Location')).toBe('https://bitrise.io/home');
-    expect(mockFetch).not.toHaveBeenCalled();
+    expectNoCacheHeaders(response);
   });
 
-  it('redirects to app.bitrise.io when logged in with no referrer', async () => {
+  it('redirects to app.bitrise.io with no-cache headers when logged in with no referrer', async () => {
     const response = await fetch('https://bitrise.io/', { cookies: 'webflow_user_redirect=1' });
     expect(response.status).toBe(302);
-    expect(response.headers.get('Location')).toBe('https://app.bitrise.io/');
-    expect(mockFetch).not.toHaveBeenCalled();
+    expect(response.headers.get('Location')).toBe('https://app.bitrise.io');
+    expectNoCacheHeaders(response);
   });
 
   it('redirects to app.bitrise.io when logged in with an external referrer', async () => {
@@ -52,28 +53,22 @@ describe('/ (root)', () => {
       referrer: 'https://google.com',
     });
     expect(response.status).toBe(302);
-    expect(response.headers.get('Location')).toBe('https://app.bitrise.io/');
+    expect(response.headers.get('Location')).toBe('https://app.bitrise.io');
   });
 });
 
 describe('/home', () => {
   it('fetches root from origin without cookie when logged in', async () => {
-    await fetch('https://bitrise.io/home', { cookies: 'webflow_user_redirect=1' });
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://bitrise.io/',
-      expect.objectContaining({ headers: expect.any(Headers) }),
-    );
+    const response = await fetch('https://bitrise.io/home', { cookies: 'webflow_user_redirect=1' });
+    expect(mockFetch).toHaveBeenCalledWith('https://bitrise.io/', expect.objectContaining({ headers: expect.any(Headers) }));
     const passedHeaders = mockFetch.mock.calls[0][1].headers;
     expect(passedHeaders.get('Cookie')).toBeNull();
+    expectNoCacheHeaders(response);
   });
 
   it('fetches root from origin without cookie when not logged in', async () => {
-    await fetch('https://bitrise.io/home');
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://bitrise.io/',
-      expect.objectContaining({ headers: expect.any(Headers) }),
-    );
-    const passedHeaders = mockFetch.mock.calls[0][1].headers;
-    expect(passedHeaders.get('Cookie')).toBeNull();
+    const response = await fetch('https://bitrise.io/home');
+    expect(mockFetch).toHaveBeenCalledWith('https://bitrise.io/', expect.objectContaining({ headers: expect.any(Headers) }));
+    expectNoCacheHeaders(response);
   });
 });

--- a/test/js/home-redirect/worker.test.js
+++ b/test/js/home-redirect/worker.test.js
@@ -66,9 +66,10 @@ describe('/home', () => {
     expectNoCacheHeaders(response);
   });
 
-  it('fetches root from origin without cookie when not logged in', async () => {
+  it('redirects to / when not logged in', async () => {
     const response = await fetch('https://bitrise.io/home');
-    expect(mockFetch).toHaveBeenCalledWith('https://bitrise.io/', expect.objectContaining({ headers: expect.any(Headers) }));
-    expectNoCacheHeaders(response);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('https://bitrise.io/');
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 });

--- a/test/js/home-redirect/worker.test.js
+++ b/test/js/home-redirect/worker.test.js
@@ -43,7 +43,7 @@ describe('/ (root)', () => {
   it('redirects to app.bitrise.io with no-cache headers when logged in with no referrer', async () => {
     const response = await fetch('https://bitrise.io/', { cookies: 'webflow_user_redirect=1' });
     expect(response.status).toBe(302);
-    expect(response.headers.get('Location')).toBe('https://app.bitrise.io');
+    expect(response.headers.get('Location')).toBe('https://app.bitrise.io/');
     expectNoCacheHeaders(response);
   });
 
@@ -53,7 +53,7 @@ describe('/ (root)', () => {
       referrer: 'https://google.com',
     });
     expect(response.status).toBe(302);
-    expect(response.headers.get('Location')).toBe('https://app.bitrise.io');
+    expect(response.headers.get('Location')).toBe('https://app.bitrise.io/');
   });
 });
 

--- a/test/js/home-redirect/worker.test.js
+++ b/test/js/home-redirect/worker.test.js
@@ -30,7 +30,7 @@ describe('/ (root)', () => {
     expectNoCacheHeaders(response);
   });
 
-  it('redirects to /home with no-cache headers when logged in with a bitrise.io referrer', async () => {
+  it('redirects to /home when logged in with a bitrise referrer', async () => {
     const response = await fetch('https://bitrise.io/', {
       cookies: 'webflow_user_redirect=1',
       referrer: 'https://bitrise.io/blog',


### PR DESCRIPTION
## Summary

Adds a `home-redirect` Cloudflare Worker on `bitrise.io` that uses the `webflow_user_redirect=1` cookie (set by the Rails monolith on login) to route logged-in users away from the marketing homepage.

### Routing logic

| Path | Cookie | Referrer | Action |
|------|--------|----------|--------|
| `/` | absent | any | passthrough |
| `/home` | absent | any | → `/` |
| `/*` | absent | any | passthrough |
| `/` | present | none / external | → `app.bitrise.io` |
| `/` | present | any bitrise hostname | → `/home` |
| `/home` | present | any | fetch `/` from origin (cookie stripped) |
| `/*` | present | any | passthrough |

The referrer distinction at `/` covers two logged-in entry points:
- **URL bar / Google** (no or external referrer): user likely wants the app → redirect to `app.bitrise.io`
- **Internal navigation** (e.g. clicking the logo on `/pricing`): user probably wants the homepage → redirect to `/home`, which serves the homepage content without a redirect loop

All responses carry `Cache-Control: no-store` and `Vary: Cookie, Referer` to prevent browsers and CDNs from caching and bypassing the worker logic on subsequent visits.

## Cookie spec (from monolith PR)

| Property | Value |
|----------|-------|
| Name | `webflow_user_redirect` |
| Value | `1` |
| Domain | `.bitrise.io` |
| Expiry | 4 days |
| Secure | yes (production only) |
| HttpOnly | yes |

## Test plan
- [x] Not logged in: bitrise.io/→ marketing homepage
- [x] Not logged in:bitrise.io/home→ 302 tobitrise.io/
- [x] Not logged in:bitrise.io/pricing→ pricing page (worker does not touch it)
- [x] Logged in, direct/Google:bitrise.io/→ 302 toapp.bitrise.io
- [x] Logged in:bitrise.io/pricing→ pricing page (worker does not touch it)
- [x] Logged in, frombitrise.io/pricing to bitrise.io/→ 302 tobitrise.io/home
- [x] Logged in:bitrise.io/home→ marketing homepage content

## Related

Jira: https://bitrise.atlassian.net/browse/ER-2723
Monolith PR: https://github.com/bitrise-io/bitrise-website/pull/19514