### PR TITLE
Allow all origins

### DIFF
--- a/src/js/stacks/worker.js
+++ b/src/js/stacks/worker.js
@@ -37,10 +37,10 @@ export default {
       const sourceURL = new URL(`https://storage.googleapis.com/bitrise-cli-tool-catalog/${toolsMatch[1]}`)
       const response = await fetch(sourceURL);
       const data = response.status == 200 ? await response.text() : "";
-      return new Response(data, {
+      return setCorsHeaders(new Response(data, {
         status: response.status,
         statusText: response.statusText,
-      });
+      }));
     }
 
     if (urlObject.pathname.match(/^\/stacks\/.+/)) {


### PR DESCRIPTION
CORS needs to allow all in order to fetch this info from localhost (which is a legit use-case in product --the local WFE-- as well as for local dev)