### PR TITLE
Fix CSS URL pattern in bitrise-navigation build to match Webflow's ne…

### DIFF
--- a/src/js/bitrise-navigation/build.js
+++ b/src/js/bitrise-navigation/build.js
@@ -8,7 +8,7 @@ const SOURCE_URL = 'https://bitrise.io/';
 const VERSION = 'v2';
 const NAV_SELECTOR = 'nav.nav_component';
 const FOOTER_SELECTOR = '.page-wrapper > footer';
-const CSS_HREF_PATTERN = /\.shared\.[a-z0-9]+\.min\.css/;
+const CSS_HREF_PATTERN = /\.shared\.[a-z0-9.]+\.min\.css/;
 const TARGET_ORIGIN = 'https://bitrise.io';
 
 const ABSOLUTE_URL_RE = /^(https?:\/\/|\/\/|#|mailto:|tel:|javascript:|data:)/i;


### PR DESCRIPTION
…w filename format

Webflow now exports the shared CSS with two dot-separated hash segments (e.g. test-e93bfd.shared.<hash1>.<hash2>.min.css) instead of one, which broke the existing regex and caused the CI build to fail with "CSS <link> ... not found".